### PR TITLE
Determine OS Type and Version if not present in the Input

### DIFF
--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -471,7 +471,8 @@ func patchSingleArchImage(
 					return nil, err
 				}
 			} else {
-				// get package manager based on os family type
+				// LINEAJE: Input may not have OS Type or Version set. Fetch these values from the OS Family instead.
+				// Return an error if either OS Type or Version could not be determined.
 				if updates.Metadata.OS.Type == "" || updates.Metadata.OS.Version == "" {
 					osType, osVersion, err := determineOSFamily(ctx, c, config)
 					updates.Metadata.OS.Type = osType


### PR DESCRIPTION
Determine OS Type and Version if not present in the Input from OS Family