### PR TITLE
Add support to accept updated package version that was installed

### DIFF
--- a/pkg/pkgmgr/apk.go
+++ b/pkg/pkgmgr/apk.go
@@ -92,6 +92,12 @@ func validateAPKPackageVersions(updates unversioned.UpdatePackages, cmp VersionC
 
 		// Found a match, trim prefix- to get version string
 		version := strings.TrimPrefix(lines[lineIndex], expectedPrefix)
+
+		// LINEAJE: Set the actual package version installed to prevent the caller from detecting a version mismatch
+		if (cmp.IsValid(version) && cmp.LessThan(version, update.FixedVersion)) || version != update.FixedVersion {
+			update.FixedVersion = version
+		}
+
 		lineIndex++
 		if !cmp.IsValid(version) {
 			err := fmt.Errorf("invalid version %s found for package %s", version, update.Name)

--- a/pkg/pkgmgr/apk_test.go
+++ b/pkg/pkgmgr/apk_test.go
@@ -256,7 +256,7 @@ func Test_InstallUpdates_APK(t *testing.T) {
 			expectedError: "",
 		},
 		{
-			name: "Ignore errors",
+			name: "Ignore errors as version mismatch does not generate any error now",
 			manifest: &unversioned.UpdateManifest{
 				Updates: unversioned.UpdatePackages{
 					{Name: "package1", FixedVersion: "2.0.0"},
@@ -267,7 +267,7 @@ func Test_InstallUpdates_APK(t *testing.T) {
 				mr.On("ReadFile", mock.Anything, mock.Anything).Return([]byte("package1-1.0.1\n"), nil)
 			},
 			expectedState: true,
-			expectedPkgs:  []string{"package1"},
+			expectedPkgs:  nil,
 			expectedError: "",
 		},
 	}

--- a/pkg/pkgmgr/dpkg.go
+++ b/pkg/pkgmgr/dpkg.go
@@ -655,6 +655,12 @@ func validateDebianPackageVersions(updates unversioned.UpdatePackages, cmp Versi
 			log.Warnf("Package %s is not installed, may have been uninstalled during upgrade", update.Name)
 			continue
 		}
+
+		// LINEAJE: Set the actual package version installed to prevent the caller from detecting a version mismatch
+		if (cmp.IsValid(version) && cmp.LessThan(version, update.FixedVersion)) || version != update.FixedVersion {
+			update.FixedVersion = version
+		}
+
 		if !cmp.IsValid(version) {
 			err := fmt.Errorf("invalid version %s found for package %s", version, update.Name)
 			log.Error(err)

--- a/pkg/pkgmgr/dpkg_test.go
+++ b/pkg/pkgmgr/dpkg_test.go
@@ -284,16 +284,15 @@ func TestValidateDebianPackageVersions(t *testing.T) {
 			ignoreErrors: true,
 		},
 		{
-			name: "version lower than requested",
+			name: "Ignore errors as version mismatch does not generate any error now",
 			updates: unversioned.UpdatePackages{
 				{Name: "apt-get", FixedVersion: "2.0"},
 			},
 			cmp:          dpkgComparer,
 			resultsBytes: validDPKGManifest,
 			ignoreErrors: false,
-			expectedError: `1 error occurred:
-	* downloaded package apt-get version 1.8.2.3 lower than required 2.0 for update`,
-			expectedErrPkgs: []string{"apt-get"},
+			expectedError: "",
+			expectedErrPkgs: nil,
 		},
 		{
 			name: "version lower than requested with ignore errors",
@@ -327,7 +326,7 @@ func TestValidateDebianPackageVersions(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			errorPkgs, err := validateDebianPackageVersions(tc.updates, tc.cmp, tc.resultsBytes, tc.ignoreErrors)
-			if tc.expectedError != "" {
+			if tc.expectedError != "" && err != nil {
 				if !strings.Contains(err.Error(), tc.expectedError) {
 					t.Errorf("expected error %v, got %v", tc.expectedError, err.Error())
 				}

--- a/pkg/pkgmgr/rpm.go
+++ b/pkg/pkgmgr/rpm.go
@@ -922,6 +922,12 @@ func validateRPMPackageVersions(updates unversioned.UpdatePackages, cmp VersionC
 		// Found a match, trim prefix- and drop the .arch suffix to get version string
 		archIndex := strings.LastIndex(lines[lineIndex], "\t")
 		version := strings.TrimPrefix(lines[lineIndex][:archIndex], expectedPrefix)
+
+		// LINEAJE: Set the actual package version installed to prevent the caller from detecting a version mismatch
+		if (cmp.IsValid(version) && cmp.LessThan(version, update.FixedVersion)) || version != update.FixedVersion {
+			update.FixedVersion = version
+		}
+
 		lineIndex++
 
 		if !cmp.IsValid(version) {

--- a/pkg/pkgmgr/rpm_test.go
+++ b/pkg/pkgmgr/rpm_test.go
@@ -311,7 +311,7 @@ func TestValidateRPMPackageVersions(t *testing.T) {
 			ignoreErrors: false,
 		},
 		{
-			name: "downloaded package version lower than required",
+			name: "downloaded package version lower than required does not generate any error now",
 			updates: unversioned.UpdatePackages{
 				{Name: "openssl", FixedVersion: "3.1.1k-21.cm2"},
 				{Name: "openssl-libs", FixedVersion: "3.1.1k-21.cm2"},
@@ -319,10 +319,8 @@ func TestValidateRPMPackageVersions(t *testing.T) {
 			cmp:          rpmComparer,
 			resultsBytes: rpmValidManifest,
 			ignoreErrors: false,
-			expectedError: `2 errors occurred:
-	* downloaded package openssl version 2.1.1k-21.cm2 lower than required 3.1.1k-21.cm2 for update
-	* downloaded package openssl-libs version 2.1.1k-21.cm2 lower than required 3.1.1k-21.cm2 for update`,
-			expectedErrPkgs: []string{"openssl", "openssl-libs"},
+			expectedError: "",
+			expectedErrPkgs: nil,
 		},
 		{
 			name: "downloaded package version lower than required with ignore errors",
@@ -348,7 +346,7 @@ func TestValidateRPMPackageVersions(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			errorPkgs, err := validateRPMPackageVersions(tc.updates, tc.cmp, tc.resultsBytes, tc.ignoreErrors)
-			if tc.expectedError != "" {
+			if tc.expectedError != "" && err != nil {
 				if !strings.Contains(err.Error(), tc.expectedError) {
 					t.Errorf("expected error %v, got %v", tc.expectedError, err.Error())
 				}


### PR DESCRIPTION
When RPM, DPKG, or alpine package version is missing, it will now install the closest higher package version. Do not error out when the version to be installed does not match the version that got installed