### PR TITLE
Save Successful and Failed patch detail in JSON file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,12 +17,13 @@ BASE_PACKAGE_NAME := github.com/project-copacetic/copacetic
 GIT_COMMIT        := $(shell git rev-list -1 HEAD)
 GIT_VERSION       := $(shell git describe --always --tags --dirty)
 BUILD_DATE        := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
+GOARCH            := $(shell go env GOARCH)
+GOOS              := $(shell go env GOOS)
 DEFAULT_LDFLAGS   := -X $(BASE_PACKAGE_NAME)/pkg/version.GitCommit=$(GIT_COMMIT) \
   -X $(BASE_PACKAGE_NAME)/pkg/version.GitVersion=$(GIT_VERSION) \
   -X $(BASE_PACKAGE_NAME)/pkg/version.BuildDate=$(BUILD_DATE) \
+  -X $(BASE_PACKAGE_NAME)/pkg/output/lineaje.version=$(CLI_VERSION)_$(GOOS)_$(GOARCH) \
   -X main.version=$(CLI_VERSION)
-GOARCH            := $(shell go env GOARCH)
-GOOS              := $(shell go env GOOS)
 
 # Message lack of native build support in Windows
 ifeq ($(GOOS),windows)
@@ -41,7 +42,7 @@ else
 endif
 
 # Build output variables
-CLI_BINARY        := copa
+CLI_BINARY        := copa_$(CLI_VERSION)_$(GOOS)_$(GOARCH)
 OUT_DIR           := ./dist
 BINS_OUT_DIR      ?= $(OUT_DIR)/$(GOOS)_$(GOARCH)/$(BUILDTYPE_DIR)
 

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/docker/go v1.5.1-1 // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
+	github.com/fatih/color v1.18.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fvbommel/sortorder v1.1.0 // indirect
@@ -140,4 +141,5 @@ require (
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gotest.tools/v3 v3.4.0 // indirect
+	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,8 @@ github.com/docker/go-metrics v0.0.1 h1:AgB/0SvBxihN0X8OR4SjsblXkbMvalQ8cjmtKQ2rQ
 github.com/docker/go-metrics v0.0.1/go.mod h1:cG1hvH2utMXtqgqqYE9plW6lDxS3/5ayHzueweSI3Vw=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
+github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
@@ -412,3 +414,5 @@ gotest.tools/v3 v3.4.0 h1:ZazjZUfuVeZGLAmlKKuyv3IKP5orXcwtOwDQH6YVr6o=
 gotest.tools/v3 v3.4.0/go.mod h1:CtbdzLSsqVhDgMtKsx03ird5YTGB3ar27v0u/yKBW5g=
 k8s.io/apimachinery v0.33.1 h1:mzqXWV8tW9Rw4VeW9rEkqvnxj59k1ezDUl20tFK/oM4=
 k8s.io/apimachinery v0.33.1/go.mod h1:BHW0YOu7n22fFv/JkYOEfkUYNRN0fj0BlvMFWA7b+SM=
+k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 h1:M3sRQVHv7vB20Xc2ybTt7ODCeFj6JSWYFzOFnYeS6Ro=
+k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=

--- a/pkg/output/lineaje/output.go
+++ b/pkg/output/lineaje/output.go
@@ -1,0 +1,86 @@
+package lineaje
+
+import (
+	"encoding/json"
+	"os"
+	"time"
+
+	"github.com/project-copacetic/copacetic/pkg/types"
+)
+
+var version string
+
+type imageDetails struct {
+	Platform           string `json:"platform"`
+	PatchedImage       string `json:"patched_image"`
+	PatchedImageDigest string `json:"patched_image_digest"`
+}
+
+type Output struct {
+	Schema           string              `json:"schema_no"`
+	Status           string              `json:"status"`
+	Message          string              `json:"message"`
+	ImageDetails     imageDetails        `json:"image_details"`
+	PatchesApplied   []types.PatchDetail `json:"patches_applied"`
+	PatchesFailed    map[string]string   `json:"patches_failed"`
+	CopaceticVersion string              `json:"copacetic_version"`
+	StartTime        string              `json:"start_time"`
+	EndTime          string              `json:"end_time"`
+	ScannerVersion   string              `json:"scanner_version"`
+}
+
+// NewLineajeOutput creates an Output instance initialized with provided patch error, result, start time, and scanner version.
+// It sets the status as "success" or "failure" based on the error presence and populates patch details if available.
+func NewLineajeOutput(
+	patchError error,
+	patchResult *types.PatchResult,
+	startTime string,
+) Output {
+	lineajeOutput := Output{
+		Schema:    "1.0",
+		Status:    "success",
+		StartTime: startTime,
+		EndTime:   time.Now().Format(time.RFC3339),
+	}
+	lineajeOutput.CopaceticVersion = "copacetic " + version
+	if patchError != nil {
+		lineajeOutput.Status = "failure"
+		lineajeOutput.Message = patchError.Error()
+	}
+	if patchResult != nil {
+		lineajeOutput.ScannerVersion = patchResult.PluginVersion
+		lineajeOutput.ImageDetails = newImageDetails("local", patchResult.PatchedRef.String(), patchResult.PatchedImageDigest)
+		lineajeOutput.PatchesApplied = patchResult.PatchesApplied
+		lineajeOutput.PatchesFailed = make(map[string]string)
+		for _, patchDetail := range patchResult.PatchesFailed {
+			lineajeOutput.PatchesFailed[patchDetail.InstalledPURL] = patchDetail.ErrorMsg
+		}
+	}
+	return lineajeOutput
+}
+
+// Save writes to the given file as pretty-printed JSON.
+func (o *Output) Save(filename string) error {
+	f, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "  ")
+	return enc.Encode(o)
+}
+
+// newImageDetails constructs an imageDetails instance.
+func newImageDetails(
+	platform string,
+	patchedImage string,
+	patchedImageDigest string,
+) imageDetails {
+	return imageDetails{
+		Platform:           platform,
+		PatchedImage:       patchedImage,
+		PatchedImageDigest: patchedImageDigest,
+	}
+}

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -1,0 +1,20 @@
+package output
+
+import (
+	"os"
+
+	"github.com/project-copacetic/copacetic/pkg/output/lineaje"
+	"github.com/project-copacetic/copacetic/pkg/types"
+)
+
+func Save(err error, result *types.PatchResult, format string, output string, startTime string) {
+	if format != "lineaje" || len(output) == 0 {
+		return
+	}
+	_, statErr := os.Stat(output)
+	if statErr == nil { // Do not overwrite the existing output file
+		return
+	}
+	newLineajeOutput := lineaje.NewLineajeOutput(err, result, startTime)
+	_ = newLineajeOutput.Save(output)
+}

--- a/pkg/pkgmgr/apk_test.go
+++ b/pkg/pkgmgr/apk_test.go
@@ -167,7 +167,7 @@ func TestValidateAPKPackageVersions(t *testing.T) {
 		// Use t.Run to run each test case as a subtest
 		t.Run(tc.name, func(t *testing.T) {
 			// Run the function to be tested
-			errorPkgs, err := validateAPKPackageVersions(tc.updates, tc.cmp, tc.resultsBytes, tc.ignoreErrors)
+			errorPkgs, _, _, err := validateAPKPackageVersions(tc.updates, tc.cmp, tc.resultsBytes, tc.ignoreErrors)
 			if tc.expectedError != "" {
 				if !strings.Contains(err.Error(), tc.expectedError) {
 					t.Errorf("expected error %v, got %v", tc.expectedError, err.Error())
@@ -256,7 +256,7 @@ func Test_InstallUpdates_APK(t *testing.T) {
 			expectedError: "",
 		},
 		{
-			name: "Ignore errors as version mismatch does not generate any error now",
+			name: "Ignore errors",
 			manifest: &unversioned.UpdateManifest{
 				Updates: unversioned.UpdatePackages{
 					{Name: "package1", FixedVersion: "2.0.0"},
@@ -267,7 +267,7 @@ func Test_InstallUpdates_APK(t *testing.T) {
 				mr.On("ReadFile", mock.Anything, mock.Anything).Return([]byte("package1-1.0.1\n"), nil)
 			},
 			expectedState: true,
-			expectedPkgs:  nil,
+			expectedPkgs:  []string{"package1"},
 			expectedError: "",
 		},
 	}
@@ -294,7 +294,7 @@ func Test_InstallUpdates_APK(t *testing.T) {
 				workingFolder: "/tmp",
 			}
 
-			state, pkgs, err := am.InstallUpdates(context.TODO(), tt.manifest, tt.ignoreErrors)
+			state, pkgs, _, _, err := am.InstallUpdates(context.TODO(), tt.manifest, tt.ignoreErrors)
 
 			if tt.expectedError != "" {
 				assert.Error(t, err)

--- a/pkg/pkgmgr/dpkg_test.go
+++ b/pkg/pkgmgr/dpkg_test.go
@@ -284,15 +284,16 @@ func TestValidateDebianPackageVersions(t *testing.T) {
 			ignoreErrors: true,
 		},
 		{
-			name: "Ignore errors as version mismatch does not generate any error now",
+			name: "version lower than requested",
 			updates: unversioned.UpdatePackages{
 				{Name: "apt-get", FixedVersion: "2.0"},
 			},
 			cmp:          dpkgComparer,
 			resultsBytes: validDPKGManifest,
 			ignoreErrors: false,
-			expectedError: "",
-			expectedErrPkgs: nil,
+			expectedError: `1 error occurred:
+	* downloaded package apt-get version 1.8.2.3 lower than required 2.0 for update`,
+			expectedErrPkgs: []string{"apt-get"},
 		},
 		{
 			name: "version lower than requested with ignore errors",
@@ -325,7 +326,7 @@ func TestValidateDebianPackageVersions(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			errorPkgs, err := validateDebianPackageVersions(tc.updates, tc.cmp, tc.resultsBytes, tc.ignoreErrors)
+			errorPkgs, _, _, err := validateDebianPackageVersions(tc.updates, tc.cmp, tc.resultsBytes, tc.ignoreErrors)
 			if tc.expectedError != "" && err != nil {
 				if !strings.Contains(err.Error(), tc.expectedError) {
 					t.Errorf("expected error %v, got %v", tc.expectedError, err.Error())

--- a/pkg/pkgmgr/rpm_test.go
+++ b/pkg/pkgmgr/rpm_test.go
@@ -311,7 +311,7 @@ func TestValidateRPMPackageVersions(t *testing.T) {
 			ignoreErrors: false,
 		},
 		{
-			name: "downloaded package version lower than required does not generate any error now",
+			name: "downloaded package version lower than required",
 			updates: unversioned.UpdatePackages{
 				{Name: "openssl", FixedVersion: "3.1.1k-21.cm2"},
 				{Name: "openssl-libs", FixedVersion: "3.1.1k-21.cm2"},
@@ -319,8 +319,10 @@ func TestValidateRPMPackageVersions(t *testing.T) {
 			cmp:          rpmComparer,
 			resultsBytes: rpmValidManifest,
 			ignoreErrors: false,
-			expectedError: "",
-			expectedErrPkgs: nil,
+			expectedError: `2 errors occurred:
+	* downloaded package openssl version 2.1.1k-21.cm2 lower than required 3.1.1k-21.cm2 for update
+	* downloaded package openssl-libs version 2.1.1k-21.cm2 lower than required 3.1.1k-21.cm2 for update`,
+			expectedErrPkgs: []string{"openssl", "openssl-libs"},
 		},
 		{
 			name: "downloaded package version lower than required with ignore errors",
@@ -345,7 +347,7 @@ func TestValidateRPMPackageVersions(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			errorPkgs, err := validateRPMPackageVersions(tc.updates, tc.cmp, tc.resultsBytes, tc.ignoreErrors)
+			errorPkgs, _, _, err := validateRPMPackageVersions(tc.updates, tc.cmp, tc.resultsBytes, tc.ignoreErrors)
 			if tc.expectedError != "" && err != nil {
 				if !strings.Contains(err.Error(), tc.expectedError) {
 					t.Errorf("expected error %v, got %v", tc.expectedError, err.Error())

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -8,17 +8,20 @@ import (
 type UpdatePackage struct {
 	Name             string `json:"name"`
 	InstalledVersion string `json:"installedVersion"`
+	InstalledPURL    string `json:"installedPURL"` // LINEAJE: Field that holds the PURL of the vulnerable package that is installed in the image
 	FixedVersion     string `json:"fixedVersion"`
+	FixedPURL        string `json:"fixedPURL"` // LINEAJE: Field that holds the PURL of the fixed package that was installed in the image
 	VulnerabilityID  string `json:"vulnerabilityID"`
 }
 
 type UpdatePackages []UpdatePackage
 
 type UpdateManifest struct {
-	OSType    string         `json:"osType"`
-	OSVersion string         `json:"osVersion"`
-	Arch      string         `json:"arch"`
-	Updates   UpdatePackages `json:"updates"`
+	OSType        string         `json:"osType"`
+	OSVersion     string         `json:"osVersion"`
+	Arch          string         `json:"arch"`
+	Updates       UpdatePackages `json:"updates"`
+	PluginVersion string         `json:"pluginVersion"` // LINEAJE: Optional field that holds the details of the Plugin that generated the report
 }
 
 // PatchPlatform is an extension of ispec.Platform but with a reportFile.
@@ -37,7 +40,21 @@ func (p PatchPlatform) String() string {
 
 // PatchResult represents the result of a single arch patch operation.
 type PatchResult struct {
-	OriginalRef reference.Named
-	PatchedDesc *ispec.Descriptor
-	PatchedRef  reference.Named
+	PluginVersion      string `json:"pluginVersion"` // LINEAJE: Optional field that holds the details of the Plugin that generated the report
+	OriginalRef        reference.Named
+	PatchedDesc        *ispec.Descriptor
+	PatchedRef         reference.Named
+	PatchedImageDigest string
+	PatchesApplied     []PatchDetail // LINEAJE: List of Patches that were successfully applied
+	PatchesFailed      []PatchDetail // LINEAJE: List of Patches that could not be applied
+}
+
+// PatchDetail represents the result of a single package operation
+type PatchDetail struct {
+	Package       string `json:"-"`
+	InputVersion  string `json:"-"`
+	OutputVersion string `json:"-"`
+	InstalledPURL string `json:"input_purl"`
+	FixedPURL     string `json:"fixed_purl"`
+	ErrorMsg      string `json:"-"`
 }

--- a/pkg/types/unversioned/types.go
+++ b/pkg/types/unversioned/types.go
@@ -1,8 +1,9 @@
 package unversioned
 
 type UpdateManifest struct {
-	Metadata Metadata       `json:"metadata"`
-	Updates  UpdatePackages `json:"updates"`
+	Metadata      Metadata       `json:"metadata"`
+	Updates       UpdatePackages `json:"updates"`
+	PluginVersion string         `json:"pluginVersion"` // LINEAJE: Optional field that holds the details of the Plugin that generated the report
 }
 
 type UpdatePackages []UpdatePackage
@@ -25,6 +26,8 @@ type Config struct {
 type UpdatePackage struct {
 	Name             string `json:"name"`
 	InstalledVersion string `json:"installedVersion"`
+	InstalledPURL    string `json:"installedPURL"` // LINEAJE: Field that holds the PURL of the vulnerable package that is installed in the image
 	FixedVersion     string `json:"fixedVersion"`
+	FixedPURL        string `json:"fixedPURL"` // LINEAJE: Field that holds the PURL of the fixed package that was installed in the image
 	VulnerabilityID  string `json:"vulnerabilityID"`
 }

--- a/pkg/types/v1alpha1/types.go
+++ b/pkg/types/v1alpha1/types.go
@@ -6,6 +6,7 @@ type UpdateManifest struct {
 	APIVersion string         `json:"apiVersion"`
 	Metadata   Metadata       `json:"metadata"`
 	Updates    UpdatePackages `json:"updates"`
+	PluginVersion string         `json:"pluginVersion"` // LINEAJE: Optional field that holds the details of the Plugin that generated the report
 }
 
 type UpdatePackages []UpdatePackage
@@ -27,6 +28,8 @@ type Config struct {
 type UpdatePackage struct {
 	Name             string `json:"name"`
 	InstalledVersion string `json:"installedVersion"`
+	InstalledPURL    string `json:"installedPURL"` // LINEAJE: Field that holds the PURL of the vulnerable package that is installed in the image
 	FixedVersion     string `json:"fixedVersion"`
+	FixedPURL        string `json:"fixedPURL"` // LINEAJE: Field that holds the PURL of the fixed package that was installed in the image
 	VulnerabilityID  string `json:"vulnerabilityID"`
 }

--- a/pkg/vex/vex.go
+++ b/pkg/vex/vex.go
@@ -23,6 +23,8 @@ func TryOutputVexDocument(updates *unversioned.UpdateManifest, pkgType, patchedI
 		if err != nil {
 			return err
 		}
+	case "lineaje": // LINEAJE: Nothing to do here for this format
+		return nil
 	default:
 		return fmt.Errorf("unsupported output format %s specified", format)
 	}


### PR DESCRIPTION
Save Successful and Failed patch detail in JSON file when "lineaje" format is specified. Set the version of the Copacetic scanner and rename the output binary to make it architecture specific.
