### PR TITLE
feat: Add Manual Build and Test and Release on Tag workflows 

### DIFF
--- a/.github/workflows/manual-build-test.yml
+++ b/.github/workflows/manual-build-test.yml
@@ -1,0 +1,59 @@
+name: Manual Build and Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref_type:
+        description: 'The type of ref to checkout (branch or tag)'
+        required: true
+        default: 'branch'
+        type: choice
+        options:
+        - branch
+        - tag
+      ref_name:
+        description: 'The name of the branch or tag to checkout'
+        required: true
+        type: string
+      version:
+        description: 'Optional version to pass to the build (e.g., 1.0.0)'
+        required: false
+        type: string
+        default: ''
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.ref_type == 'branch' && format('refs/heads/{0}', github.event.inputs.ref_name) || format('refs/tags/{0}', github.event.inputs.ref_name) }}
+
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.24' # Consistent Go version
+
+      - name: Configure Docker daemon for containerd snapshotter
+        run: |
+          echo '{"features": { "containerd-snapshotter": true }}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
+
+      - name: Build Copacetic CLI
+        run: |
+          if [[ -n "${{ github.event.inputs.version }}" ]]; then
+            make CLI_VERSION=${{ github.event.inputs.version }}
+          else
+            make
+          fi
+
+      - name: Test
+        run: make test
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-artifacts
+          path: dist/linux_amd64/release/

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -1,0 +1,60 @@
+name: Create GitHub Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      CLI_VERSION:
+        description: 'CLI Version (e.g., 1.0.0)'
+        required: true
+        type: string
+      TAG_NAME:
+        description: 'Tag for the release (e.g., v1.0.0)'
+        required: true
+        type: string
+
+jobs:
+  release:
+    name: Build Release Assets
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      release_archive_name: ${{ steps.get_archive_name.outputs.name }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.TAG_NAME }} # Checkout the specified tag
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.24' # Updated Go version
+
+      - name: Run build
+        run: |
+          make CLI_VERSION=${{ inputs.CLI_VERSION }}
+
+      - name: Determine Archive Name
+        id: get_archive_name
+        # Produces an archive name like copacetic-1.0.0_linux_amd64.tar.gz
+        run: echo "name=copacetic-${{ steps.get_version.outputs.version }}_linux_amd64.tar.gz" >> $GITHUB_OUTPUT
+
+      - name: Create Release Archive
+        run: |
+          tar -czvf ${{ steps.get_archive_name.outputs.name }} -C dist/linux_amd64/release/ .
+
+      - name: Create Release and Upload Asset
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ steps.get_archive_name.outputs.name }}
+          tag_name: ${{ inputs.TAG_NAME }} # Release on the specified tag
+          # The release will be created for the tag that triggered the workflow.
+          # GITHUB_TOKEN is automatically provided.
+          # Customize the release name and body if needed, e.g.:
+          # name: Release ${{ github.ref_name }}
+          # body: "Automated release for version ${{ github.ref_name }}"
+          # Prerelease will be marked if the tag contains a hyphen (e.g., v1.0.0-alpha)
+          # This is a default behavior of softprops/action-gh-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Updates the GitHub Actions workflows:

    - .github/workflows/manual-build-test.yml:
      - Manually triggered workflow (`workflow_dispatch`).
      - Sets up Go environment (version 1.24).
      - Configures Docker daemon with `containerd-snapshotter: true` and restarts Docker.
      - Build command: `make CLI_VERSION=${{ inputs.CLI_VERSION }}`.
      - Test command: `make test`.

    - .github/workflows/release-on-tag.yml:
      - Manually triggered workflow (`workflow_dispatch`) for releases.
      - Sets up Go environment (version 1.24).
      - Build command: `make CLI_VERSION=${{ inputs.CLI_VERSION }}`.
      - Creates a GitHub release.