### PR TITLE
Use correct Package variable for RPM patching

### DIFF
--- a/pkg/pkgmgr/rpm.go
+++ b/pkg/pkgmgr/rpm.go
@@ -516,7 +516,7 @@ func (rm *rpmManager) installUpdates(ctx context.Context, updates unversioned.Up
     										)
   										else
     										versions=$(
-      											"$TOOL" list available "${$PKG}.${ARCH}" --showduplicates 2>/dev/null \
+      											"$TOOL" list available "${PKG}.${ARCH}" --showduplicates 2>/dev/null \
         											| awk "{print \$2}" | sort -V | uniq
     										)
   										fi


### PR DESCRIPTION
Yum package installer in RPM package manager has an extra `$` causing failure in next version finding logic.